### PR TITLE
solve a fix when minify a directive

### DIFF
--- a/src/bc-qr-reader.js.coffee
+++ b/src/bc-qr-reader.js.coffee
@@ -51,4 +51,4 @@ bcQrReader = ($timeout) ->
 
 angular
   .module('bcQrReader', [])
-  .directive('bcQrReader', bcQrReader)
+  .directive('bcQrReader', ['$timeout', bcQrReader])


### PR DESCRIPTION
When use ngAnnotate in grunt, var $timeout is not uglified correctly.