### PR TITLE
Fix for active becoming false-y and not stoping active media tracks

### DIFF
--- a/dist/bc-qr-reader.js
+++ b/dist/bc-qr-reader.js
@@ -3815,6 +3815,13 @@ bcQrReader = function($timeout) {
       cameraStatus: '='
     },
     template: '<div><webcam on-stream="onStream(stream)" on-error="onError(err)" ng-if="active" channel="channel"></webcam><canvas id="qr-canvas"></canvas></div>',
+    controller: function(scope, elem, attrs) {
+      return scope.$watch('active', function(newVal) {
+        if (newVal === false && scope.qrStream) {
+          scope.qrStream.getTracks()[0].stop();
+        }
+      });
+    },
     link: function(scope, elem, attrs) {
       scope.channel = {};
       if (!scope.onError) {
@@ -3856,6 +3863,6 @@ bcQrReader = function($timeout) {
   };
 };
 
-angular.module('bcQrReader', []).directive('bcQrReader', bcQrReader);
+angular.module('bcQrReader', []).directive('bcQrReader', ['$timeout', bcQrReader]);
 
 })()

--- a/src/bc-qr-reader.js.coffee
+++ b/src/bc-qr-reader.js.coffee
@@ -10,6 +10,11 @@ bcQrReader = ($timeout) ->
       cameraStatus: '='
     }
     template: '<div><webcam on-stream="onStream(stream)" on-error="onError(err)" ng-if="active" channel="channel"></webcam><canvas id="qr-canvas"></canvas></div>'
+    controller: (scope, elem, attrs) ->
+      scope.$watch 'active', (newVal) ->
+        if newVal == false and scope.qrStream
+          scope.qrStream.getTracks()[0].stop()
+        return
     link: (scope, elem, attrs) ->
       scope.channel = {}
 


### PR DESCRIPTION
#14 references this issue which is simply fixed by adding a watcher for the active scope property and upon it becoming false-y calling any open tracks on the media object and stopping them.